### PR TITLE
Better handling of failed downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.failsafe.version>2.19.1</maven.failsafe.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
         <exec.maven.plugin.version>1.2</exec.maven.plugin.version>
-        <download.maven.plugin.version>1.2.1</download.maven.plugin.version>
+        <download.maven.plugin.version>1.3.0</download.maven.plugin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <opencsv.version>2.4</opencsv.version>
         <metrics3.version>3.0.1</metrics3.version>
@@ -362,7 +362,9 @@
                                 <configuration>
                                     <url>https://github.com/JanusGraph/janusgraph/releases/download/v${janusgraph.version}/janusgraph-${janusgraph.version}-hadoop2.zip</url>
                                     <unpack>false</unpack>
-                                    <outputDirectory>${project.build.directory}/../server</outputDirectory>
+				    <outputDirectory>${project.build.directory}/../server</outputDirectory>
+				    <skipCache>true</skipCache>
+				    <overwrite>true</overwrite>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <maven.failsafe.version>2.19.1</maven.failsafe.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
         <exec.maven.plugin.version>1.2</exec.maven.plugin.version>
-        <download.maven.plugin.version>1.3.0</download.maven.plugin.version>
+        <download.maven.plugin.version>1.2.1</download.maven.plugin.version>
         <slf4j.version>1.7.21</slf4j.version>
         <opencsv.version>2.4</opencsv.version>
         <metrics3.version>3.0.1</metrics3.version>
@@ -40,6 +40,8 @@
         <include.category></include.category>
         <exclude.category></exclude.category>
         <test.excluded.groups>org.janusgraph.testcategory.MemoryTests,org.janusgraph.testcategory.PerformanceTests,org.janusgraph.testcategory.BrittleTests,org.janusgraph.testcategory.OrderedKeyStoreTests,org.janusgraph.testcategory.SerialTests</test.excluded.groups>
+	<download.skip.cache>false</download.skip.cache>
+	<download.force.overwrite>false</download.force.overwrite>
     </properties>
     <developers>
         <developer>
@@ -275,6 +277,8 @@
                                     <url>https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip</url>
                                     <unpack>true</unpack>
                                     <outputDirectory>${project.build.directory}/dynamodb</outputDirectory>
+				    <skipCache>${download.skip.cache}</skipCache>
+				    <overwrite>${download.force.overwrite}</overwrite>
                                 </configuration>
                             </execution>
                         </executions>
@@ -363,8 +367,8 @@
                                     <url>https://github.com/JanusGraph/janusgraph/releases/download/v${janusgraph.version}/janusgraph-${janusgraph.version}-hadoop2.zip</url>
                                     <unpack>false</unpack>
 				    <outputDirectory>${project.build.directory}/../server</outputDirectory>
-				    <skipCache>true</skipCache>
-				    <overwrite>true</overwrite>
+				    <skipCache>${download.skip.cache}</skipCache>
+				    <overwrite>${download.force.overwrite}</overwrite>
                                 </configuration>
                             </execution>
                         </executions>
@@ -390,6 +394,8 @@
                                     <url>https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip</url>
                                     <unpack>true</unpack>
                                     <outputDirectory>${project.build.directory}/dynamodb</outputDirectory>
+				    <skipCache>${download.skip.cache}</skipCache>
+				    <overwrite>${download.force.overwrite}</overwrite>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/test/resources/install-gremlin-server.sh
+++ b/src/test/resources/install-gremlin-server.sh
@@ -16,9 +16,38 @@ set -eux
 # permissions and limitations under the License.
 #
 
+usage() {
+    echo "Usage: $0 [options]" >&2
+    echo "Options:" >&2
+    echo " -f      force overwriting of the cached files" >&2
+}
+
+MVN_OPT_PARAMS=""
+
+args=$(getopt fh $*)
+if [ $? != 0 ] ; then
+    usage
+    exit 1
+fi
+
+set -- $args
+
+for i ; do
+    case "$i" in
+        -f)
+            MVN_OPT_PARAMS="$MVN_OPT_PARAMS -Ddownload.skip.cache=true -Ddownload.force.overwrite=true"
+            shift;;
+        -h)
+            usage
+            exit 0;;
+        --)
+            shift; break;;
+    esac
+done
+
 #collect the prereqs and build the plugin
 export MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
-mvn -q -T 1C install -Dmaven.test.skip=true -DskipTests=true
+mvn -q -T 1C install -Dmaven.test.skip=true -DskipTests=true $MVN_OPT_PARAMS
 
 # Directory structure of server directory
 # -src
@@ -35,12 +64,12 @@ mvn -q -T 1C install -Dmaven.test.skip=true -DskipTests=true
 # |-dependencies
 # |
 
-export ARTIFACT_NAME=`mvn -q -Dexec.executable="echo" -Dexec.args='${project.artifactId}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
+export ARTIFACT_NAME=`mvn -q -Dexec.executable="echo" -Dexec.args='${project.artifactId}' $MVN_OPT_PARAMS --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
 export JANUSGRAPH_DYNAMODB_HOME=${PWD}
 export JANUSGRAPH_DYNAMODB_TARGET=${JANUSGRAPH_DYNAMODB_HOME}/target
-export JANUSGRAPH_VERSION=`mvn -q -Dexec.executable="echo" -Dexec.args='${janusgraph.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
+export JANUSGRAPH_VERSION=`mvn -q -Dexec.executable="echo" -Dexec.args='${janusgraph.version}' $MVN_OPT_PARAMS --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
 #Extract the DYNAMODB version from the pom.
-export DYNAMODB_PLUGIN_VERSION=`mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
+export DYNAMODB_PLUGIN_VERSION=`mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' $MVN_OPT_PARAMS --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
 export JANUSGRAPH_VANILLA_SERVER_DIRNAME=janusgraph-${JANUSGRAPH_VERSION}-hadoop2
 export JANUSGRAPH_VANILLA_SERVER_ZIP=${JANUSGRAPH_VANILLA_SERVER_DIRNAME}.zip
 export JANUSGRAPH_DYNAMODB_SERVER_DIRNAME=${ARTIFACT_NAME}-${DYNAMODB_PLUGIN_VERSION}
@@ -63,7 +92,7 @@ export JANUSGRAPH_SERVER_SERVICE_SH=${JANUSGRAPH_SERVER_BIN}/gremlin-server-serv
 mkdir -p ${WORKDIR}
 
 #download the server products
-mvn test -q -Pdownload-janusgraph-server-zip > /dev/null 2>&1
+mvn test -q -Pdownload-janusgraph-server-zip $MVN_OPT_PARAMS > /dev/null 2>&1
 
 #verify
 pushd target
@@ -82,7 +111,7 @@ mkdir -p ${JANUSGRAPH_DYNAMODB_EXT_DIR}
 cp ${JANUSGRAPH_DYNAMODB_TARGET}/${ARTIFACT_NAME}-${DYNAMODB_PLUGIN_VERSION}.jar ${JANUSGRAPH_DYNAMODB_EXT_DIR}
 cp -R ${JANUSGRAPH_DYNAMODB_TARGET}/dependencies/*.* ${JANUSGRAPH_DYNAMODB_EXT_DIR}
 #fix bad dependencies
-mkdir ${JANUSGRAPH_SERVER_HOME}/badlibs
+mkdir -p ${JANUSGRAPH_SERVER_HOME}/badlibs
 pushd ${JANUSGRAPH_SERVER_HOME}/lib
 mv joda-time-1.6.2.jar ${JANUSGRAPH_SERVER_HOME}/badlibs
 mv jackson-core-2.4.4.jar ${JANUSGRAPH_SERVER_HOME}/badlibs


### PR DESCRIPTION
Switched to newer version of the download plugin which fails on
incomplete downloads. Disabled cache polling for large server ZIP file
and enabled overwriting of the target file.